### PR TITLE
Allow to skip building wasm when testing.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-odra"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "cargo-generate",
  "cargo_toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ description = "A cargo utility that helps to create, manage and test your smart 
 keywords = ["wasm", "webassembly", "blockchain"]
 categories = ["wasm", "smart contracts"]
 name = "cargo-odra"
-version = "0.0.4"
+version = "0.0.5"
 edition = "2021"
 
 [dependencies]

--- a/justfile
+++ b/justfile
@@ -10,7 +10,7 @@ prepare-test-env:
 
 test-project-generation:
     rm -rf testproject
-    cargo odra new --name testproject --git-branch release/0.2.0
+    cargo odra new --name testproject
     cd testproject && cargo odra generate -c plascoin
     cd testproject && cargo odra test
     cd testproject && cargo odra test -b casper

--- a/justfile
+++ b/justfile
@@ -10,7 +10,7 @@ prepare-test-env:
 
 test-project-generation:
     rm -rf testproject
-    cargo odra new --name testproject --git-branch 0.2.0
+    cargo odra new --name testproject --git-branch release/0.2.0
     cd testproject && cargo odra generate -c plascoin
     cd testproject && cargo odra test
     cd testproject && cargo odra test -b casper

--- a/src/actions/generate.rs
+++ b/src/actions/generate.rs
@@ -84,7 +84,7 @@ impl GenerateAction {
         command::append_file(paths::project_lib_rs(), &register_module_code);
 
         // Print info.
-        log::info(format!("Added to src/lib.rs:\n{}", register_module_code));
+        log::info(format!("Added to src/lib.rs:\n{register_module_code}"));
     }
 
     /// Add contract definition to Odra.toml.

--- a/src/actions/test.rs
+++ b/src/actions/test.rs
@@ -7,15 +7,21 @@ use crate::{command, paths};
 pub struct TestAction {
     backend: Option<String>,
     passthrough_args: Vec<String>,
+    skip_build: bool,
 }
 
 /// TestAction implementation.
 impl TestAction {
     /// Creates a TestAction struct.
-    pub fn new(backend: Option<String>, passthrough_args: Vec<String>) -> TestAction {
+    pub fn new(
+        backend: Option<String>,
+        passthrough_args: Vec<String>,
+        skip_build: bool,
+    ) -> TestAction {
         TestAction {
             backend,
             passthrough_args,
+            skip_build,
         }
     }
 
@@ -24,7 +30,9 @@ impl TestAction {
         if self.backend.is_none() {
             self.test_mock_vm();
         } else {
-            self.build_wasm_files();
+            if !self.skip_build {
+                self.build_wasm_files();
+            }
             self.test_backend();
         }
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -88,6 +88,9 @@ pub struct TestCommand {
     /// A list of arguments is passed to the cargo test command.
     #[clap(raw = true)]
     pub args: Vec<String>,
+    /// Skip building wasm files.
+    #[clap(value_parser, long, short, default_value = "false")]
+    pub skip_build: bool,
 }
 
 #[derive(clap::Args, Debug)]
@@ -118,7 +121,7 @@ pub fn make_action() {
             BuildAction::new(build.backend).build();
         }
         OdraSubcommand::Test(test) => {
-            TestAction::new(test.backend, test.args).test();
+            TestAction::new(test.backend, test.args, test.skip_build).test();
         }
         OdraSubcommand::Generate(generate) => {
             GenerateAction::new(generate.contract_name).generate_contract();

--- a/src/command.rs
+++ b/src/command.rs
@@ -97,7 +97,7 @@ fn cargo(current_dir: PathBuf, command: &str, tail_args: Vec<&str>) {
 
     parse_command_result(
         command,
-        Error::CommandFailed(format!("Couldn't run cargo with args {:?}", args)),
+        Error::CommandFailed(format!("Couldn't run cargo with args {args:?}")),
     );
 }
 
@@ -126,7 +126,7 @@ pub fn cargo_build_wasm_sources(current_dir: PathBuf, contract_name: &str) {
         "run",
         vec![
             "--bin",
-            format!("{}_build", contract_name).as_str(),
+            format!("{contract_name}_build").as_str(),
             "--release",
             "--no-default-features",
             "--target-dir",

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -50,7 +50,7 @@ impl BuilderPaths {
 
     /// Returns *_build.rs path.
     pub fn wasm_build(&self, contract_name: &str) -> PathBuf {
-        self.src().join(format!("{}_build.rs", contract_name))
+        self.src().join(format!("{contract_name}_build.rs"))
     }
 
     /// Returns *_build.rs path as a String.
@@ -63,7 +63,7 @@ impl BuilderPaths {
 
     /// Returns *_wasm.rs path.
     pub fn wasm_source(&self, contract_name: &str) -> PathBuf {
-        self.src().join(format!("{}_wasm.rs", contract_name))
+        self.src().join(format!("{contract_name}_wasm.rs"))
     }
 
     /// Returns *_wasm.rs path as a String.


### PR DESCRIPTION
It's possible to run this:
```bash
cargo odra test -b casper --skip-build
```
This was handy when I needed to edit raw WASM file between building and testing. 