### PR TITLE
Remove `--lib` arg from cargo_test_odra_vm and cargo_test_backend functions

### DIFF
--- a/src/actions/test.rs
+++ b/src/actions/test.rs
@@ -101,8 +101,7 @@ impl TestFilters {
             _ => self
                 .targets
                 .iter()
-                .map(|t| vec!["--test", t.as_str()])
-                .flatten()
+                .flat_map(|t| vec!["--test", t.as_str()])
                 .collect(),
         };
 

--- a/src/actions/test.rs
+++ b/src/actions/test.rs
@@ -1,5 +1,4 @@
 //! Module responsible for running contracts tests.
-
 use super::build::BuildAction;
 use crate::{command, log, project::Project};
 
@@ -9,7 +8,7 @@ pub struct TestAction<'a> {
     backend: Option<String>,
     passthrough_args: Vec<String>,
     skip_build: bool,
-    test: Option<String>,
+    filters: TestFilters,
 }
 
 /// TestAction implementation.
@@ -18,16 +17,18 @@ impl<'a> TestAction<'a> {
     pub fn new(
         project: &Project,
         backend: Option<String>,
-        test: Option<String>,
         passthrough_args: Vec<String>,
         skip_build: bool,
+        tests: Vec<String>,
+        filter: Option<String>,
     ) -> TestAction {
+        let filters = TestFilters::new(tests, filter);
         TestAction {
             backend,
             passthrough_args,
             skip_build,
             project,
-            test,
+            filters,
         }
     }
 }
@@ -48,7 +49,12 @@ impl TestAction<'_> {
     /// Test code against OdraVM.
     fn test_odra_vm(&self) {
         log::info("Testing against OdraVM ...");
-        command::cargo_test_odra_vm(self.project.project_root(), self.args());
+
+        command::cargo_test_odra_vm(
+            self.project.project_root(),
+            &self.filters,
+            self.get_passthrough_args(),
+        );
     }
 
     /// Test specific backend.
@@ -57,7 +63,8 @@ impl TestAction<'_> {
         command::cargo_test_backend(
             self.project.project_root(),
             self.backend_name(),
-            self.args(),
+            &self.filters,
+            self.get_passthrough_args(),
         );
     }
 
@@ -71,23 +78,38 @@ impl TestAction<'_> {
         self.passthrough_args.iter().map(AsRef::as_ref).collect()
     }
 
-    /// Returns arguments to be passed to `cargo test` command.
-    ///
-    /// This includes the test name and passthrough arguments.
-    fn args(&self) -> Vec<&str> {
-        [
-            self.test
-                .as_ref()
-                .map(|t| vec![t.as_str()])
-                .unwrap_or_default(),
-            self.get_passthrough_args(),
-        ]
-        .concat()
-    }
-
     /// Build *.wasm files before testing.
     fn build_wasm_files(&self) {
         BuildAction::new(self.project, None).build();
         log::info("Building finished.")
+    }
+}
+
+pub struct TestFilters {
+    targets: Vec<String>,
+    filter: Option<String>,
+}
+
+impl TestFilters {
+    fn new(targets: Vec<String>, filter: Option<String>) -> Self {
+        Self { targets, filter }
+    }
+
+    pub fn as_args(&self) -> Vec<&str> {
+        let mut args = match &self.targets.len() {
+            0 => vec!["--tests"],
+            _ => self
+                .targets
+                .iter()
+                .map(|t| vec!["--test", t.as_str()])
+                .flatten()
+                .collect(),
+        };
+
+        if let Some(filter) = &self.filter {
+            args.push(filter.as_str());
+        }
+
+        args
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -118,9 +118,12 @@ pub struct TestCommand {
     /// Skip building wasm files.
     #[clap(value_parser, long, short, default_value = "false")]
     pub skip_build: bool,
-    /// Run only tests containing the given name.
+    /// Test only the specified test target.
     #[clap(value_parser, long, short)]
-    pub test: Option<String>,
+    pub test: Vec<String>,
+    /// Run only tests containing the given name.
+    #[clap(value_parser)]
+    pub filter: Option<String>,
 }
 
 #[derive(clap::Args, Debug)]
@@ -176,9 +179,10 @@ pub fn make_action() {
             TestAction::new(
                 &project,
                 test.backend,
-                test.test,
                 test.args,
                 test.skip_build,
+                test.test,
+                test.filter,
             )
             .test();
         }

--- a/src/command.rs
+++ b/src/command.rs
@@ -12,6 +12,7 @@ use clap::Parser;
 use Error::InvalidInternalCommand;
 
 use crate::{
+    actions::test::TestFilters,
     cli::Cargo,
     consts::{ODRA_BACKEND_ENV_KEY, ODRA_MODULE_ENV_KEY},
     errors::Error,
@@ -150,18 +151,27 @@ pub fn cargo_generate_schema_files(current_dir: PathBuf, contract_name: &str, mo
 }
 
 /// Runs cargo test.
-pub fn cargo_test_odra_vm(current_dir: PathBuf, mut args: Vec<&str>) {
+pub fn cargo_test_odra_vm<'a>(
+    current_dir: PathBuf,
+    filters: &'a TestFilters,
+    mut args: Vec<&'a str>,
+) {
     log::info("Running cargo test...");
-    let mut tail_args = vec![];
+    let mut tail_args = filters.as_args();
     tail_args.append(&mut args);
     cargo(current_dir, "test", tail_args);
 }
 
 /// Runs cargo test with backend features.
-pub fn cargo_test_backend(project_root: PathBuf, backend_name: &str, mut args: Vec<&str>) {
+pub fn cargo_test_backend<'a>(
+    project_root: PathBuf,
+    backend_name: &str,
+    filters: &'a TestFilters,
+    mut args: Vec<&'a str>,
+) {
     env::set_var(ODRA_BACKEND_ENV_KEY, backend_name);
     log::info("Running cargo test...");
-    let mut tail_args = vec![];
+    let mut tail_args = filters.as_args();
     tail_args.append(&mut args);
     cargo(project_root, "test", tail_args)
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -152,7 +152,7 @@ pub fn cargo_generate_schema_files(current_dir: PathBuf, contract_name: &str, mo
 /// Runs cargo test.
 pub fn cargo_test_odra_vm(current_dir: PathBuf, mut args: Vec<&str>) {
     log::info("Running cargo test...");
-    let mut tail_args = vec!["--lib"];
+    let mut tail_args = vec![];
     tail_args.append(&mut args);
     cargo(current_dir, "test", tail_args);
 }
@@ -161,7 +161,7 @@ pub fn cargo_test_odra_vm(current_dir: PathBuf, mut args: Vec<&str>) {
 pub fn cargo_test_backend(project_root: PathBuf, backend_name: &str, mut args: Vec<&str>) {
     env::set_var(ODRA_BACKEND_ENV_KEY, backend_name);
     log::info("Running cargo test...");
-    let mut tail_args = vec!["--lib"];
+    let mut tail_args = vec![];
     tail_args.append(&mut args);
     cargo(project_root, "test", tail_args)
 }

--- a/src/odra_toml.rs
+++ b/src/odra_toml.rs
@@ -22,7 +22,7 @@ impl Contract {
             .split_terminator("::")
             .next()
             .unwrap_or_else(|| MalformedFqn.print_and_die())
-            .replace("-", "_")
+            .replace('-', "_")
             .to_string()
     }
 
@@ -31,7 +31,7 @@ impl Contract {
             project
                 .members
                 .iter()
-                .find(|m| m.name.replace("-", "_") == self.module_name())
+                .find(|m| m.name.replace('-', "_") == self.module_name())
                 .unwrap_or_else(|| {
                     Error::CrateOfContractNotFound(self.module_name()).print_and_die()
                 })
@@ -101,7 +101,7 @@ impl OdraToml {
                 .split_terminator("::")
                 .next()
                 .unwrap_or_else(|| Error::MalformedFqn.print_and_die())
-                == crate_name.replace("-", "_")
+                == crate_name.replace('-', "_")
         })
     }
 }


### PR DESCRIPTION
Now, the command `cargo odra test` does the same thing as `cargo test`.